### PR TITLE
Making dropdown component reusable

### DIFF
--- a/src/components/Dropdown.js
+++ b/src/components/Dropdown.js
@@ -4,6 +4,8 @@ import { caretDownOutline, downloadSharp } from "ionicons/icons";
 import { IonIcon } from "@ionic/react";
 import Button from "./Button";
 
+// Make this component reusable by removing anything that has to do with the download dropdown menu.
+
 export default function Dropdown({ onClick = () => {}, disabled = false }) {
   return (
     <div className="flex items-center justify-center">

--- a/src/components/LoginDropdown.js
+++ b/src/components/LoginDropdown.js
@@ -4,6 +4,8 @@ import { personCircleSharp } from "ionicons/icons";
 import { IonIcon } from "@ionic/react";
 import Button from "./Button";
 
+// Once the dropdown component is reusable, this file will eventually be deleted.
+
 export default function Dropdown({ onClick = () => {} }) {
   return (
     <div className="flex items-center justify-center">


### PR DESCRIPTION
fixes for #289 

### To-Do List:
#### Component Reusability 
- [ ] make Dropdown component in `Dropdown.js` reusable by removing anything that is specific to the the download dropdown.
- [ ] Successful completion of PREVIOUS to-do should result in `LoginDropdown.js` to be deleted.

#### Fixes for Login Dropdown specifically
- [ ] display user's avatar when user is logged in (should use freesound.me() )
- [ ] "Logged in as ____" should display user's first name or username (@hamirmahal @amilajack thoughts on this?)
- [ ] Log Out option in dropdown menu should be functional