### PR TITLE
close #309 by updating tsconfig to rm err messages

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,6 @@
     "module": "esnext",
     "moduleResolution": "node",
     "resolveJsonModule": true,
-    "isolatedModules": true,
     "noEmit": true,
     "jsx": "react-jsx",
     "types": [
@@ -24,6 +23,7 @@
     ]
   },
   "include": [
-    "src"
+    "src",
+    "cypress"
   ]
 }


### PR DESCRIPTION
This pull request will close #309 if we merge it by updating [`tsconfig.json`](https://github.com/tide-app/tide/blob/master/tsconfig.json) to include [this repository's `cypress` directory](https://github.com/tide-app/tide/tree/master/cypress), and remove the line `    "isolatedModules": true,` from [line 19 of `tsconfig.json`](https://github.com/tide-app/tide/blob/24418f05ca0b002965b0a2aad2fed01ede688592/tsconfig.json#L19).

This removes stops those error messages mentioned in #309 from appearing on hover!